### PR TITLE
Add negative tests for reader _read_text

### DIFF
--- a/reader.py
+++ b/reader.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+from typing import Union
+
+
+def _read_text(path: Union[str, Path]) -> str:
+    """Read and return text from the given path.
+
+    Parameters
+    ----------
+    path: Union[str, Path]
+        Path to the text file.
+
+    Returns
+    -------
+    str
+        The contents of the file.
+    """
+    p = Path(path)
+    # Path.read_text will raise FileNotFoundError if the path does not exist
+    # and IsADirectoryError if the path is a directory.
+    return p.read_text()

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -1,0 +1,18 @@
+import pytest
+from pathlib import Path
+
+from reader import _read_text
+
+
+def test_read_text_nonexistent_path(tmp_path):
+    # create a path that does not exist
+    non_existent = tmp_path / "missing.txt"
+    assert not non_existent.exists()
+    with pytest.raises(FileNotFoundError):
+        _read_text(non_existent)
+
+
+def test_read_text_directory(tmp_path):
+    # tmp_path is a directory itself
+    with pytest.raises(IsADirectoryError):
+        _read_text(tmp_path)


### PR DESCRIPTION
## Summary
- Add `reader._read_text` for reading text files, relying on `Path.read_text`
- Test error handling for nonexistent file and directory inputs

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689eae0e2bc48326bd0dc1dd5817aa5d